### PR TITLE
Fix formatting string warnings for mac address printing

### DIFF
--- a/multiloop_test.c
+++ b/multiloop_test.c
@@ -1,6 +1,6 @@
-
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include <openssl/evp.h>
 #include <openssl/bio.h>
@@ -11,13 +11,13 @@
 void test_callback(const helium_connection_t *conn, uint64_t sender_mac, char * const message, size_t count)
 {
   helium_dbg("1 Function-pointer callback got %s %zd\n", message, count);
-  helium_dbg("1 Mac address is %lu\n", sender_mac);
+  helium_dbg("1 Mac address is %" PRIu64 "\n", sender_mac);
 }
 
 void test_callback2(const helium_connection_t *conn, uint64_t sender_mac, char * const message, size_t count)
 {
   helium_dbg("2 Function-pointer callback got %s %zd\n", message, count);
-  helium_dbg("2 Mac address is %lu\n", sender_mac);
+  helium_dbg("2 Mac address is %" PRIu64 "\n", sender_mac);
 }
 
 void _run_my_loop(void *arg)

--- a/test.c
+++ b/test.c
@@ -1,6 +1,6 @@
-
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include <openssl/evp.h>
 #include <openssl/bio.h>
@@ -11,7 +11,7 @@
 void test_callback(const helium_connection_t *conn, uint64_t sender_mac, char * const message, size_t count)
 {
   helium_dbg("Function-pointer callback got %s %zd\n", message, count);
-  helium_dbg("Mac address is %lu\n", sender_mac);
+  helium_dbg("Mac address is %" PRIu64 "\n", sender_mac);
 }
 
 int main(int argc, char *argv[])
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   char message[1024];
   int ret;
   while(1) {
-    ret = scanf("%lx %s %[^\n]", &mac, token_in, message);
+    ret = scanf("%" PRIx64 " %s %[^\n]", &mac, token_in, message);
     if (ret > 0) {
       helium_base64_token_decode(token_in, strlen((char*)token_in), token);
       if (strncmp("s", message, 1) == 0) {


### PR DESCRIPTION
This fixes compiler warnings by changing the mac address formatting
from using unsigned long to using the PRI*64 macros in debug and logging
messages.
