### PR TITLE
Implement client-side unsubscribe

### DIFF
--- a/include/helium.h
+++ b/include/helium.h
@@ -104,6 +104,15 @@ int helium_open_b(helium_connection_t *conn, char *proxy_addr, helium_block_t ca
 int helium_subscribe(helium_connection_t *conn, uint64_t macaddr, helium_token_t token);
 
 /**
+   @brief Unsubscribe from messages from the specified device.
+   @param conn The connection which will receive messages
+   @param macaddr The MAC address of the device to subscribe to
+   @return 0 on success.
+*/
+int helium_unsubscribe(helium_connection_t *conn, uint64_t macaddr);
+
+
+/**
    @brief Send a given device a message.
    @param conn The connection that will send this message
    @param macaddr The MAC address of the destination device

--- a/include/helium_internal.h
+++ b/include/helium_internal.h
@@ -60,4 +60,8 @@ int _handle_subscribe_request(helium_connection_t *conn,
                               uint64_t macaddr,
                               helium_token_t token);
 
+
+int _handle_unsubscribe_request(helium_connection_t *conn,
+                              uint64_t macaddr);
+
 int _handle_quit(helium_connection_t *conn);

--- a/samples/shell.c
+++ b/samples/shell.c
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
       if (strncmp("s", message, 1) == 0) {
         int  err = helium_subscribe(conn, mac, token);
         helium_dbg("subscribe result %d\n", err);
+      } else if (strncmp("u", message, 1) == 0) {
+        int  err = helium_unsubscribe(conn, mac);
+        helium_dbg("unsubscribe result %d\n", err);
       } else {
         int  err = helium_send(conn, mac, token, (unsigned char*)message, strlen(message));
         helium_dbg("send result %d\n", err);


### PR DESCRIPTION
This sends a 'u', for unsubscribe, message to the router, but the router
is currently ignoring it. It does delete the token from the hashmap, so
incoming packets won't be decoded or sent to the subscribe callback, at
least.
