### PR TITLE
Make sure failed requests are freed.

### DIFF
--- a/src/helium.c
+++ b/src/helium.c
@@ -162,7 +162,7 @@ void _async_callback(uv_async_t *async)
   uv_sem_post(&conn->sem);
 
   if (result != 0) {
-    helium_dbg("Request %p, of type %d, failed!", (void *)request, (int)request->request_type);
+    helium_dbg("Request %p, of type %d, failed with error code %d", (void *)request, (int)request->request_type, result);
   }
 
   free(request);


### PR DESCRIPTION
Fixes issue #37. Do we want to log errors if result != 0, @Vagabond?
