### PR TITLE
Fix a race when initializing libhelium and fix scanf usage in shell

### DIFF
--- a/samples/shell.c
+++ b/samples/shell.c
@@ -29,7 +29,8 @@ int main(int argc, char *argv[])
   helium_token_t token;
   unsigned char token_in[32];
   char message[1024];
-  int ret;
+  int ret = 0;
+  int err = 0;
 
   helium_logging_start();
   conn = helium_alloc();
@@ -50,17 +51,18 @@ int main(int argc, char *argv[])
 #endif
 
   while(1) {
-    ret = scanf("%" PRIx64 " %s %[^\n]", &mac, token_in, message);
-    if (ret > 0) {
+    ret = scanf("%"PRIx64"%*[ ]%[a-zA-Z0-9+/=]%*[ ]%[^\n]", &mac, token_in, message);
+    if (ret == 3) {
+      fflush(stdin); /* flush the newline and anything after it */
       helium_base64_token_decode(token_in, strlen((char*)token_in), token);
       if (strncmp("s", message, 1) == 0) {
-        int  err = helium_subscribe(conn, mac, token);
+        err = helium_subscribe(conn, mac, token);
         helium_dbg("subscribe result %d\n", err);
       } else if (strncmp("u", message, 1) == 0) {
-        int  err = helium_unsubscribe(conn, mac);
+        err = helium_unsubscribe(conn, mac);
         helium_dbg("unsubscribe result %d\n", err);
       } else {
-        int  err = helium_send(conn, mac, token, (unsigned char*)message, strlen(message));
+        err = helium_send(conn, mac, token, (unsigned char*)message, strlen(message));
         helium_dbg("send result %d\n", err);
       }
     } else {

--- a/src/helium.c
+++ b/src/helium.c
@@ -511,7 +511,6 @@ helium_connection_t *helium_alloc(void)
   uv_mutex_init(&conn->mutex);
 
   uv_loop_init(conn->loop);
-  uv_thread_create(conn->thread, _run_uv_loop, conn);
 
   return conn;
 }
@@ -611,7 +610,11 @@ int helium_open(helium_connection_t *conn, const char *proxy_addr, helium_callba
     return err;
   }
 
-  return 0;
+  /* XXX we have to create the thread here instead of helium_alloc because there
+   * are no handlers on the loop in alloc() and so the thread can exit instantly */
+  err = uv_thread_create(conn->thread, _run_uv_loop, conn);
+
+  return err;
 }
 
 int helium_subscribe(helium_connection_t *conn, uint64_t macaddr, helium_token_t token)


### PR DESCRIPTION
We were starting a thread with uv_loop_run with a loop with no handlers
on it, this caused a race where the thread could exit before
helium_alloc had run, thus making all the other helium functions block
waiting on a thread that was already dead. The fix is to start the
thread once we've set up all the loop handles in helium_open.

This also fixes some bugs with scanf. We weren't chomping the newline
from stdin on a successful match, nor were we checking that exactly the
right number of inputs was being matched. Both of these have been fixed.
