### PR TITLE
Add dependency information to libhelium packages

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -31,7 +31,7 @@ ifneq ($(ISDEB),)
 OSNAME        = Debian
 PKGTYPE       = deb
 OUTTYPE       = -t $(PKGTYPE)
-PKGOPTIONS    = --prefix=/usr -d 'libuv (>= v1.0.0)'
+PKGOPTIONS    = --prefix=/usr -d 'libuv (>= 1.0.0)'
 BUILDCMD      =  $(OUTTYPE) $(PKGOPTIONS) $(SHAREDFLAGS)
 else
 ifneq ($(ISSLES),)


### PR DESCRIPTION
Adds requirement on libuv packages for Debian and RedHat builds.  

See: https://packagecloud.io/helium/libhelium to test that the dependency information works.  I tested on Debian 7 and CentOS 7 (the only distros we have packages for ATM).
