### PR TITLE
Fix OpenSSL version detection.

### DIFF
--- a/cmake-scripts/Findopenssl.cmake
+++ b/cmake-scripts/Findopenssl.cmake
@@ -35,16 +35,17 @@ ENDIF(OPENSSL_FOUND)
 SET(OPENSSL_MINIMUM_VERSION "1.0.1")
 
 IF(OPENSSL_FOUND)
-  file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str REGEX "^#define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x[0-9][0-9][0-9][0-9][0-9][0-9].*")
-  
+  file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
+    REGEX "^#[\t ]?define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x[0-9].*")
+
   string(REGEX REPLACE "^.*OPENSSL_VERSION_NUMBER[\t ]+0x([0-9]).*$" "\\1" OPENSSL_VERSION_MAJOR "${openssl_version_str}")
   string(REGEX REPLACE "^.*OPENSSL_VERSION_NUMBER[\t ]+0x[0-9][0-9]([0-9][0-9]).*$" "\\1" OPENSSL_VERSION_MINOR  "${openssl_version_str}")
   string(REGEX REPLACE "^.*OPENSSL_VERSION_NUMBER[\t ]+0x[0-9][0-9][0-9]([0-9][0-9]).*$" "\\1" OPENSSL_VERSION_PATCH "${openssl_version_str}")
-    
+
   string(REGEX REPLACE "^0" "" OPENSSL_VERSION_MINOR "${OPENSSL_VERSION_MINOR}")
   string(REGEX REPLACE "^0" "" OPENSSL_VERSION_PATCH "${OPENSSL_VERSION_PATCH}")
 
-  # hack: the above regex-replaces consume versions of the form "00" too greedily, 
+  # hack: the above regex-replaces consume versions of the form "00" too greedily,
   # giving us an empty string, so make sure they're 0 if empty.
   if(OPENSSL_VERSION_MINOR STREQUAL "")
     SET(OPENSSL_VERSION_MINOR "0")
@@ -53,11 +54,11 @@ IF(OPENSSL_FOUND)
   if(OPENSSL_VERSION_PATCH STREQUAL "")
     SET(OPENSSL_VERSION_PATCH "0")
   endif(OPENSSL_VERSION_PATCH STREQUAL "")
-    
+
   set(OPENSSL_VERSION "${OPENSSL_VERSION_MAJOR}.${OPENSSL_VERSION_MINOR}.${OPENSSL_VERSION_PATCH}")
 
   if(${OPENSSL_VERSION} VERSION_LESS ${OPENSSL_MINIMUM_VERSION})
     message(FATAL_ERROR "OpenSSL version found (${OPENSSL_VERSION}) is less then the minimum required (${OpenSSL_FIND_VERSION}), aborting.")
   endif(${OPENSSL_VERSION} VERSION_LESS ${OPENSSL_MINIMUM_VERSION})
-  
+
 ENDIF (OPENSSL_FOUND)


### PR DESCRIPTION
More recent OpenSSL versions change the spacing of the OPENSSL_VERSION_NUMBER constant, breaking the cmake script that uses a regex to determine the value of this constant.

Shout out to Joe Damato for helping me fix this. Dude's a prince.
